### PR TITLE
[SOL-335] Success badge on transfer successful screen

### DIFF
--- a/lib/screens/transfer/transfer_successful_screen.dart
+++ b/lib/screens/transfer/transfer_successful_screen.dart
@@ -9,6 +9,7 @@ import 'package:solarisdemo/redux/app_state.dart';
 import 'package:solarisdemo/screens/home/home_screen.dart';
 import 'package:solarisdemo/screens/transactions/transactions_screen.dart';
 import 'package:solarisdemo/utilities/format.dart';
+import 'package:solarisdemo/widgets/app_toolbar.dart';
 import 'package:solarisdemo/widgets/button.dart';
 import 'package:solarisdemo/widgets/ivory_asset_with_badge.dart';
 import 'package:solarisdemo/widgets/screen_scaffold.dart';
@@ -42,6 +43,10 @@ class TransferSuccessfulScreen extends StatelessWidget {
       shouldPop: false,
       body: Column(
         children: [
+          AppToolbar(
+            backButtonEnabled: false,
+            padding: ClientConfig.getCustomClientUiSettings().defaultScreenHorizontalPadding,
+          ),
           Expanded(
             child: ScrollableScreenContainer(
               child: Padding(
@@ -49,7 +54,6 @@ class TransferSuccessfulScreen extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    const Spacer(),
                     Align(
                       alignment: Alignment.centerLeft,
                       child: Text(

--- a/lib/screens/transfer/transfer_successful_screen.dart
+++ b/lib/screens/transfer/transfer_successful_screen.dart
@@ -13,6 +13,7 @@ import 'package:solarisdemo/widgets/app_toolbar.dart';
 import 'package:solarisdemo/widgets/button.dart';
 import 'package:solarisdemo/widgets/ivory_asset_with_badge.dart';
 import 'package:solarisdemo/widgets/screen_scaffold.dart';
+import 'package:solarisdemo/widgets/screen_title.dart';
 import 'package:solarisdemo/widgets/scrollable_screen_container.dart';
 
 import '../../utilities/ivory_color_mapper.dart';
@@ -54,14 +55,7 @@ class TransferSuccessfulScreen extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Align(
-                      alignment: Alignment.centerLeft,
-                      child: Text(
-                        "Transfer successful",
-                        style: ClientConfig.getTextStyleScheme().heading1,
-                        textAlign: TextAlign.left,
-                      ),
-                    ),
+                    const ScreenTitle("Transfer successful"),
                     const SizedBox(height: 16),
                     StoreConnector<AppState, TransferViewModel>(
                       converter: (store) => TransferPresenter.presentTransfer(

--- a/lib/screens/transfer/transfer_successful_screen.dart
+++ b/lib/screens/transfer/transfer_successful_screen.dart
@@ -1,3 +1,4 @@
+import 'package:badges/badges.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
@@ -9,6 +10,7 @@ import 'package:solarisdemo/screens/home/home_screen.dart';
 import 'package:solarisdemo/screens/transactions/transactions_screen.dart';
 import 'package:solarisdemo/utilities/format.dart';
 import 'package:solarisdemo/widgets/button.dart';
+import 'package:solarisdemo/widgets/ivory_asset_with_badge.dart';
 import 'package:solarisdemo/widgets/screen_scaffold.dart';
 import 'package:solarisdemo/widgets/scrollable_screen_container.dart';
 
@@ -115,10 +117,12 @@ class TransferSuccessfulScreen extends StatelessWidget {
                       ),
                     ),
                     const Spacer(),
-                    Center(
-                      child: SvgPicture(
+                    IvoryAssetWithBadge(
+                      isSuccess: true,
+                      childPosition: BadgePosition.topEnd(top: -32, end: -32),
+                      childWidget: SvgPicture(
                         SvgAssetLoader(
-                          'assets/images/repayment_more_credit.svg',
+                          'assets/images/transfer_successful_illustration.svg',
                           colorMapper: IvoryColorMapper(
                             baseColor: ClientConfig.getColorScheme().secondary,
                           ),


### PR DESCRIPTION
## Changes
- Changed image to `assets/images/transfer_successful_illustration.svg` on the success transfer screen (previously was a wrong image)
- Added successful animated badge
- Added AppToolbar with the back button disabled and removed the Spacer() that was wrongly used before the title

## Screenshots
![Screenshot 2023-10-09 at 13 34 46](https://github.com/ivoryio/Ivory/assets/127083262/da017932-d738-4ad2-840a-10567f1f10ab)

