### PR TITLE
TextField input type + support for changing obscureText from controller

### DIFF
--- a/lib/screens/onboarding/signup/onboarding_basic_info_screen.dart
+++ b/lib/screens/onboarding/signup/onboarding_basic_info_screen.dart
@@ -92,15 +92,15 @@ class _OnboardingBasicInfoScreenState extends State<OnboardingBasicInfoScreen> {
                   IvoryTextField(
                     label: "First name(s)",
                     placeholder: "Type first name",
-                    textCapitalization: TextCapitalization.words,
                     controller: _firstNameController,
+                    inputType: TextFieldInputType.name,
                   ),
                   const SizedBox(height: 24),
                   IvoryTextField(
                     label: "Last name(s)",
                     placeholder: "Type last name",
-                    textCapitalization: TextCapitalization.words,
                     controller: _lastNameController,
+                    inputType: TextFieldInputType.name,
                   ),
                   const Spacer(),
                   const SizedBox(height: 24),


### PR DESCRIPTION
- Added `inputType` to `IvoryTextField` which can be: `text`, `name`, `email`,  or `number`. Depending on the value of `inputType`, we will have a specific keyboard type, input formatter (fixes the issue where the user can input anything for "name" fields), or text capitalization (capitalize the first letter of the name when inputType is `TextFieldInputType.name`)
- Added `setObscureText(bool value)` to `IvoryTextFieldController`
- Added getter `IvoryTextFieldController.obscureText` (returns `bool`)