### PR TITLE
[SOL-398] Resume Onboarding after Identity Verification 

### DIFF
--- a/lib/infrastructure/onboarding/identity_verification/onboarding_identity_verification_middleware.dart
+++ b/lib/infrastructure/onboarding/identity_verification/onboarding_identity_verification_middleware.dart
@@ -101,7 +101,7 @@ class OnboardingIdentityVerificationMiddleware extends MiddlewareClass<AppState>
       if (response is FinalizeIdentificationSuccessResponse) {
         store.dispatch(FinalizeIdentificationSuccessEventAction());
       } else if (response is IdentityVerificationServiceErrorResponse) {
-        store.dispatch(OnboardingIdentityVerificationErrorEventAction(errorType: response.errorType));
+        store.dispatch(FinalizeIdentificationErrorEventAction(errorType: response.errorType));
       }
     }
   }

--- a/lib/infrastructure/onboarding/identity_verification/onboarding_identity_verification_presenter.dart
+++ b/lib/infrastructure/onboarding/identity_verification/onboarding_identity_verification_presenter.dart
@@ -18,6 +18,7 @@ class OnboardingIdentityVerificationPresenter {
       isTanConfirmed: identityVerificationState.isTanConfirmed,
       creditLimit: identityVerificationState.creditLimit,
       isScoringSuccessful: getScoringSuccessState(notificationState),
+      isIdentificationSuccessful: identityVerificationState.isIdentificationSuccessful,
     );
   }
 
@@ -41,6 +42,7 @@ class OnboardingIdentityVerificationViewModel extends Equatable {
   final bool? isTanConfirmed;
   final int? creditLimit;
   final bool? isScoringSuccessful;
+  final bool? isIdentificationSuccessful;
 
   const OnboardingIdentityVerificationViewModel({
     this.urlForIntegration,
@@ -51,6 +53,7 @@ class OnboardingIdentityVerificationViewModel extends Equatable {
     this.isTanConfirmed,
     this.creditLimit,
     this.isScoringSuccessful,
+    this.isIdentificationSuccessful,
   });
 
   @override
@@ -62,6 +65,7 @@ class OnboardingIdentityVerificationViewModel extends Equatable {
         isAuthorized,
         isTanConfirmed,
         creditLimit,
-        isScoringSuccessful
+        isScoringSuccessful,
+        isIdentificationSuccessful,
       ];
 }

--- a/lib/ivory_app.dart
+++ b/lib/ivory_app.dart
@@ -22,6 +22,7 @@ import 'package:solarisdemo/screens/onboarding/financial_details/onboarding_taxI
 import 'package:solarisdemo/screens/onboarding/identity_verification/onboarding_bank_verification_screen.dart';
 import 'package:solarisdemo/screens/onboarding/identity_verification/onboarding_contracts_confirm_screen.dart';
 import 'package:solarisdemo/screens/onboarding/identity_verification/onboarding_credit_limit_congratulations_screen.dart';
+import 'package:solarisdemo/screens/onboarding/identity_verification/onboarding_identity_verification_error_screen.dart';
 import 'package:solarisdemo/screens/onboarding/identity_verification/onboarding_identity_verification_method_screen.dart';
 import 'package:solarisdemo/screens/onboarding/identity_verification/onboarding_reference_account_iban.dart';
 import 'package:solarisdemo/screens/onboarding/identity_verification/onboarding_scoring_rejected_screen.dart';
@@ -293,6 +294,8 @@ class _IvoryAppState extends State<IvoryApp> with WidgetsBindingObserver {
             OnboardingCreditLimitCongratulationsScreen.routeName: (context) =>
                 const OnboardingCreditLimitCongratulationsScreen(),
             OnboardingScoringRejectedScreen.routeName: (context) => const OnboardingScoringRejectedScreen(),
+            OnboardingIdentityVerificationErrorScreen.routeName: (context) =>
+                const OnboardingIdentityVerificationErrorScreen(),
             //onboarding/card_configuration
             OnboardingOrderCardScreen.routeName: (context) => const OnboardingOrderCardScreen(),
             OnboardingConfigureCardScreen.routeName: (context) => const OnboardingConfigureCardScreen(),

--- a/lib/redux/onboarding/identity_verification/onboarding_identity_verification_action.dart
+++ b/lib/redux/onboarding/identity_verification/onboarding_identity_verification_action.dart
@@ -60,3 +60,9 @@ class FinalizeIdentificationCommandAction {}
 class FinalizeIdentificationLoadingEventAction {}
 
 class FinalizeIdentificationSuccessEventAction {}
+
+class FinalizeIdentificationErrorEventAction {
+  final OnboardingIdentityVerificationErrorType errorType;
+
+  FinalizeIdentificationErrorEventAction({required this.errorType});
+}

--- a/lib/redux/onboarding/identity_verification/onboarding_identity_verification_reducer.dart
+++ b/lib/redux/onboarding/identity_verification/onboarding_identity_verification_reducer.dart
@@ -54,6 +54,13 @@ OnboardingIdentityVerificationState identityVerificationReducer(
       isIdentificationSuccessful: true,
       creditLimit: state.creditLimit,
     );
+  } else if (action is FinalizeIdentificationErrorEventAction) {
+    return OnboardingIdentityVerificationState(
+      isLoading: false,
+      errorType: action.errorType,
+      creditLimit: state.creditLimit,
+      isIdentificationSuccessful: false,
+    );
   }
 
   return state;

--- a/lib/redux/onboarding/identity_verification/onboarding_identity_verification_reducer.dart
+++ b/lib/redux/onboarding/identity_verification/onboarding_identity_verification_reducer.dart
@@ -48,6 +48,12 @@ OnboardingIdentityVerificationState identityVerificationReducer(
       isLoading: true,
       creditLimit: state.creditLimit,
     );
+  } else if (action is FinalizeIdentificationSuccessEventAction) {
+    return OnboardingIdentityVerificationState(
+      isLoading: false,
+      isIdentificationSuccessful: true,
+      creditLimit: state.creditLimit,
+    );
   }
 
   return state;

--- a/lib/redux/onboarding/identity_verification/onboarding_identity_verification_state.dart
+++ b/lib/redux/onboarding/identity_verification/onboarding_identity_verification_state.dart
@@ -10,6 +10,7 @@ class OnboardingIdentityVerificationState extends Equatable {
   final bool? isTanConfirmed;
   final bool? isAuthorized;
   final int? creditLimit;
+  final bool? isIdentificationSuccessful;
 
   const OnboardingIdentityVerificationState({
     this.urlForIntegration,
@@ -19,9 +20,18 @@ class OnboardingIdentityVerificationState extends Equatable {
     this.errorType,
     this.isTanConfirmed,
     this.creditLimit,
+    this.isIdentificationSuccessful,
   });
 
   @override
-  List<Object?> get props =>
-      [urlForIntegration, isLoading, errorType, status, isAuthorized, isTanConfirmed, creditLimit];
+  List<Object?> get props => [
+        urlForIntegration,
+        isLoading,
+        errorType,
+        status,
+        isAuthorized,
+        isTanConfirmed,
+        creditLimit,
+        isIdentificationSuccessful,
+      ];
 }

--- a/lib/screens/onboarding/identity_verification/onboarding_contracts_confirm_screen.dart
+++ b/lib/screens/onboarding/identity_verification/onboarding_contracts_confirm_screen.dart
@@ -36,7 +36,7 @@ class _OnboardingContractsConfirmScreenState extends State<OnboardingContractsCo
       onWillChange: (previousViewModel, newViewModel) {
         if (newViewModel is DocumentsConfirmedViewModel) {
           Navigator.pushNamedAndRemoveUntil(context, OnboardingReferenceAccountIbanScreen.routeName, (route) => false);
-        } else if (newViewModel is DocumentsConfirmErrorViewModel) {
+        } else if (newViewModel is DocumentsErrorViewModel || newViewModel is DocumentsConfirmErrorViewModel) {
           Navigator.pushNamedAndRemoveUntil(
             context,
             OnboardingIdentityVerificationErrorScreen.routeName,

--- a/lib/screens/onboarding/identity_verification/onboarding_contracts_confirm_screen.dart
+++ b/lib/screens/onboarding/identity_verification/onboarding_contracts_confirm_screen.dart
@@ -5,6 +5,7 @@ import 'package:solarisdemo/infrastructure/documents/documents_presenter.dart';
 import 'package:solarisdemo/infrastructure/documents/documents_service.dart';
 import 'package:solarisdemo/redux/app_state.dart';
 import 'package:solarisdemo/redux/documents/documents_action.dart';
+import 'package:solarisdemo/screens/onboarding/identity_verification/onboarding_identity_verification_error_screen.dart';
 import 'package:solarisdemo/screens/onboarding/identity_verification/onboarding_reference_account_iban.dart';
 import 'package:solarisdemo/widgets/animated_linear_progress_indicator.dart';
 import 'package:solarisdemo/widgets/app_toolbar.dart';
@@ -35,6 +36,12 @@ class _OnboardingContractsConfirmScreenState extends State<OnboardingContractsCo
       onWillChange: (previousViewModel, newViewModel) {
         if (newViewModel is DocumentsConfirmedViewModel) {
           Navigator.pushNamedAndRemoveUntil(context, OnboardingReferenceAccountIbanScreen.routeName, (route) => false);
+        } else if (newViewModel is DocumentsConfirmErrorViewModel) {
+          Navigator.pushNamedAndRemoveUntil(
+            context,
+            OnboardingIdentityVerificationErrorScreen.routeName,
+            (route) => false,
+          );
         }
       },
       distinct: true,

--- a/lib/screens/onboarding/identity_verification/onboarding_credit_limit_congratulations_screen.dart
+++ b/lib/screens/onboarding/identity_verification/onboarding_credit_limit_congratulations_screen.dart
@@ -7,6 +7,7 @@ import 'package:solarisdemo/config.dart';
 import 'package:solarisdemo/infrastructure/onboarding/identity_verification/onboarding_identity_verification_presenter.dart';
 import 'package:solarisdemo/redux/app_state.dart';
 import 'package:solarisdemo/redux/onboarding/identity_verification/onboarding_identity_verification_action.dart';
+import 'package:solarisdemo/screens/onboarding/identity_verification/onboarding_identity_verification_error_screen.dart';
 import 'package:solarisdemo/screens/onboarding/onboarding_stepper_screen.dart';
 import 'package:solarisdemo/utilities/ivory_color_mapper.dart';
 import 'package:solarisdemo/widgets/animated_linear_progress_indicator.dart';
@@ -41,6 +42,12 @@ class _OnboardingCreditLimitCongratulationsScreenState extends State<OnboardingC
       onWillChange: (previousViewModel, newViewModel) {
         if (newViewModel.isIdentificationSuccessful == true) {
           Navigator.pushNamedAndRemoveUntil(context, OnboardingStepperScreen.routeName, (route) => false);
+        } else if (newViewModel.errorType != null) {
+          Navigator.pushNamedAndRemoveUntil(
+            context,
+            OnboardingIdentityVerificationErrorScreen.routeName,
+            (route) => false,
+          );
         }
       },
       distinct: true,

--- a/lib/screens/onboarding/identity_verification/onboarding_credit_limit_congratulations_screen.dart
+++ b/lib/screens/onboarding/identity_verification/onboarding_credit_limit_congratulations_screen.dart
@@ -7,6 +7,7 @@ import 'package:solarisdemo/config.dart';
 import 'package:solarisdemo/infrastructure/onboarding/identity_verification/onboarding_identity_verification_presenter.dart';
 import 'package:solarisdemo/redux/app_state.dart';
 import 'package:solarisdemo/redux/onboarding/identity_verification/onboarding_identity_verification_action.dart';
+import 'package:solarisdemo/screens/onboarding/onboarding_stepper_screen.dart';
 import 'package:solarisdemo/utilities/ivory_color_mapper.dart';
 import 'package:solarisdemo/widgets/animated_linear_progress_indicator.dart';
 import 'package:solarisdemo/widgets/app_toolbar.dart';
@@ -33,9 +34,15 @@ class _OnboardingCreditLimitCongratulationsScreenState extends State<OnboardingC
     double halfBadgeSize = IvoryAssetWithBadge.badgeSize / 2;
 
     return StoreConnector<AppState, OnboardingIdentityVerificationViewModel>(
-      converter: (store) => OnboardingIdentityVerificationPresenter.present(
-          identityVerificationState: store.state.onboardingIdentityVerificationState),
       onInit: (store) => store.dispatch(GetCreditLimitCommandAction()),
+      converter: (store) => OnboardingIdentityVerificationPresenter.present(
+        identityVerificationState: store.state.onboardingIdentityVerificationState,
+      ),
+      onWillChange: (previousViewModel, newViewModel) {
+        if (newViewModel.isIdentificationSuccessful == true) {
+          Navigator.pushNamedAndRemoveUntil(context, OnboardingStepperScreen.routeName, (route) => false);
+        }
+      },
       distinct: true,
       builder: (context, viewModel) {
         return ScreenScaffold(

--- a/lib/screens/onboarding/identity_verification/onboarding_credit_limit_congratulations_screen.dart
+++ b/lib/screens/onboarding/identity_verification/onboarding_credit_limit_congratulations_screen.dart
@@ -1,4 +1,5 @@
 import 'package:badges/badges.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -7,7 +8,6 @@ import 'package:solarisdemo/config.dart';
 import 'package:solarisdemo/infrastructure/onboarding/identity_verification/onboarding_identity_verification_presenter.dart';
 import 'package:solarisdemo/redux/app_state.dart';
 import 'package:solarisdemo/redux/onboarding/identity_verification/onboarding_identity_verification_action.dart';
-import 'package:solarisdemo/screens/onboarding/identity_verification/onboarding_identity_verification_error_screen.dart';
 import 'package:solarisdemo/screens/onboarding/onboarding_stepper_screen.dart';
 import 'package:solarisdemo/utilities/ivory_color_mapper.dart';
 import 'package:solarisdemo/widgets/animated_linear_progress_indicator.dart';
@@ -16,8 +16,10 @@ import 'package:solarisdemo/widgets/button.dart';
 import 'package:solarisdemo/widgets/circular_loading_indicator.dart';
 import 'package:solarisdemo/widgets/custom_builder.dart';
 import 'package:solarisdemo/widgets/ivory_asset_with_badge.dart';
+import 'package:solarisdemo/widgets/modal.dart';
 import 'package:solarisdemo/widgets/screen_scaffold.dart';
 import 'package:solarisdemo/widgets/scrollable_screen_container.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class OnboardingCreditLimitCongratulationsScreen extends StatefulWidget {
   static const routeName = '/onboardingCreditLimitCongratsScreen';
@@ -43,11 +45,7 @@ class _OnboardingCreditLimitCongratulationsScreenState extends State<OnboardingC
         if (newViewModel.isIdentificationSuccessful == true) {
           Navigator.pushNamedAndRemoveUntil(context, OnboardingStepperScreen.routeName, (route) => false);
         } else if (newViewModel.errorType != null) {
-          Navigator.pushNamedAndRemoveUntil(
-            context,
-            OnboardingIdentityVerificationErrorScreen.routeName,
-            (route) => false,
-          );
+          _showServerErrorBottomSheet(context);
         }
       },
       distinct: true,
@@ -168,6 +166,53 @@ class _OnboardingCreditLimitCongratulationsScreenState extends State<OnboardingC
           ),
         );
       },
+    );
+  }
+
+  void _showServerErrorBottomSheet(BuildContext context) {
+    showBottomModal(
+      context: context,
+      showCloseButton: false,
+      isDismissible: false,
+      title: 'Server error',
+      textWidget: RichText(
+        text: TextSpan(style: ClientConfig.getTextStyleScheme().bodyLargeRegular, children: [
+          const TextSpan(
+            text:
+                'We encountered an unexpected technical error. Please try again. If the issue persists, please contact our support team at ',
+          ),
+          TextSpan(
+              text: "+49 (0)123 456789",
+              style: ClientConfig.getTextStyleScheme()
+                  .bodyLargeRegularBold
+                  .copyWith(color: ClientConfig.getColorScheme().secondary),
+              recognizer: TapGestureRecognizer()
+                ..onTap = () async {
+                  final telUri = Uri(
+                    scheme: 'tel',
+                    path: '+490123456789',
+                  );
+
+                  if (await canLaunchUrl(telUri)) {
+                    await launchUrl(telUri);
+                  }
+                }),
+          const TextSpan(text: '.')
+        ]),
+      ),
+      content: Column(
+        children: [
+          const SizedBox(height: 24),
+          PrimaryButton(
+            text: "Try again",
+            onPressed: () {
+              Navigator.pop(context);
+              StoreProvider.of<AppState>(context).dispatch(FinalizeIdentificationCommandAction());
+            },
+          ),
+          const SizedBox(height: 16),
+        ],
+      ),
     );
   }
 }

--- a/lib/screens/onboarding/identity_verification/onboarding_identity_verification_error_screen.dart
+++ b/lib/screens/onboarding/identity_verification/onboarding_identity_verification_error_screen.dart
@@ -1,0 +1,77 @@
+import 'package:badges/badges.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:solarisdemo/config.dart';
+import 'package:solarisdemo/utilities/ivory_color_mapper.dart';
+import 'package:solarisdemo/widgets/app_toolbar.dart';
+import 'package:solarisdemo/widgets/button.dart';
+import 'package:solarisdemo/widgets/ivory_asset_with_badge.dart';
+import 'package:solarisdemo/widgets/screen_scaffold.dart';
+import 'package:solarisdemo/widgets/screen_title.dart';
+import 'package:solarisdemo/widgets/scrollable_screen_container.dart';
+
+class OnboardingIdentityVerificationErrorScreen extends StatelessWidget {
+  static const routeName = "/onboardingIdentityVerificationErrorScreen";
+
+  const OnboardingIdentityVerificationErrorScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ScreenScaffold(
+      body: ScrollableScreenContainer(
+        padding: ClientConfig.getCustomClientUiSettings().defaultScreenPadding,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const AppToolbar(),
+            const ScreenTitle("Your identity verification has failed"),
+            const SizedBox(height: 16),
+            Text.rich(
+              TextSpan(
+                style: ClientConfig.getTextStyleScheme().bodyLargeRegular,
+                children: [
+                  const TextSpan(text: 'We regret to inform you that your '),
+                  TextSpan(
+                    text: 'identity verification ',
+                    style: ClientConfig.getTextStyleScheme().bodyLargeRegularBold,
+                  ),
+                  const TextSpan(text: 'has not been successful due to a '),
+                  TextSpan(
+                    text: 'technical issue',
+                    style: ClientConfig.getTextStyleScheme().bodyLargeRegularBold,
+                  ),
+                  const TextSpan(text: '.\n\n'),
+                  const TextSpan(text: 'Please get in touch with us by tapping on the '),
+                  TextSpan(
+                    text: 'button below',
+                    style: ClientConfig.getTextStyleScheme().bodyLargeRegularBold,
+                  ),
+                  const TextSpan(text: '.'),
+                ],
+              ),
+            ),
+            Expanded(
+              child: IvoryAssetWithBadge(
+                childWidget: SvgPicture(
+                  SvgAssetLoader(
+                    'assets/images/repayment_more_credit.svg',
+                    colorMapper: IvoryColorMapper(
+                      baseColor: ClientConfig.getColorScheme().secondary,
+                    ),
+                  ),
+                ),
+                childPosition: BadgePosition.topEnd(top: -5, end: 78),
+                isSuccess: false,
+              ),
+            ),
+            PrimaryButton(
+              text: "Contact us",
+              onPressed: () {},
+            ),
+            const SizedBox(height: 16),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/onboarding/identity_verification/onboarding_identity_verification_method_screen.dart
+++ b/lib/screens/onboarding/identity_verification/onboarding_identity_verification_method_screen.dart
@@ -52,7 +52,7 @@ class _OnboardingIdentityVerificationMethodScreenState extends State<OnboardingI
                           title: "Bank Identification",
                           subtitle:
                               "We will verify your identity by triggering a transfer of 0.01€ from your reference bank account. Available anytime.",
-                          timeEstimation: "2 MIN",
+                          timeEstimation: "5 MIN",
                           value: "bankIdentification",
                         ),
                         RadioSelectItem(

--- a/lib/screens/onboarding/identity_verification/onboarding_reference_account_iban.dart
+++ b/lib/screens/onboarding/identity_verification/onboarding_reference_account_iban.dart
@@ -8,6 +8,7 @@ import 'package:solarisdemo/infrastructure/onboarding/identity_verification/onbo
 import 'package:solarisdemo/redux/app_state.dart';
 import 'package:solarisdemo/redux/onboarding/identity_verification/onboarding_identity_verification_action.dart';
 import 'package:solarisdemo/screens/onboarding/identity_verification/onboarding_bank_verification_screen.dart';
+import 'package:solarisdemo/screens/onboarding/identity_verification/onboarding_identity_verification_error_screen.dart';
 import 'package:solarisdemo/widgets/animated_linear_progress_indicator.dart';
 import 'package:solarisdemo/widgets/app_toolbar.dart';
 import 'package:solarisdemo/widgets/button.dart';
@@ -67,6 +68,12 @@ class _OnboardingReferenceAccountIbanScreenState extends State<OnboardingReferen
           Navigator.pushReplacementNamed(
             context,
             OnboardingBankVerificationScreen.routeName,
+          );
+        } else if (newViewModel.errorType != null) {
+          Navigator.pushNamedAndRemoveUntil(
+            context,
+            OnboardingIdentityVerificationErrorScreen.routeName,
+            (route) => false,
           );
         }
       },

--- a/lib/screens/onboarding/identity_verification/onboarding_review_updated_contracts_screen.dart
+++ b/lib/screens/onboarding/identity_verification/onboarding_review_updated_contracts_screen.dart
@@ -1,26 +1,20 @@
-import 'package:badges/badges.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:flutter_svg/svg.dart';
 import 'package:solarisdemo/config.dart';
 import 'package:solarisdemo/infrastructure/documents/documents_presenter.dart';
 import 'package:solarisdemo/infrastructure/documents/documents_service.dart';
 import 'package:solarisdemo/infrastructure/onboarding/identity_verification/onboarding_identity_verification_presenter.dart';
-import 'package:solarisdemo/models/onboarding/onboarding_identification_status.dart';
 import 'package:solarisdemo/redux/app_state.dart';
 import 'package:solarisdemo/redux/documents/documents_action.dart';
 import 'package:solarisdemo/redux/onboarding/identity_verification/onboarding_identity_verification_action.dart';
+import 'package:solarisdemo/screens/onboarding/identity_verification/onboarding_identity_verification_error_screen.dart';
 import 'package:solarisdemo/screens/onboarding/identity_verification/onboarding_sign_with_tan_screen.dart';
-import 'package:solarisdemo/utilities/ivory_color_mapper.dart';
 import 'package:solarisdemo/widgets/animated_linear_progress_indicator.dart';
 import 'package:solarisdemo/widgets/app_toolbar.dart';
 import 'package:solarisdemo/widgets/button.dart';
 import 'package:solarisdemo/widgets/circular_loading_indicator.dart';
 import 'package:solarisdemo/widgets/documents_list_view.dart';
-import 'package:solarisdemo/widgets/ivory_asset_with_badge.dart';
 import 'package:solarisdemo/widgets/screen_scaffold.dart';
-import 'package:solarisdemo/widgets/screen_title.dart';
-import 'package:solarisdemo/widgets/scrollable_screen_container.dart';
 
 class OnboardingReviewUpdatedContractsScreen extends StatelessWidget {
   static const routeName = "/onboardingReviewUpdatedContractsScreen";
@@ -37,30 +31,32 @@ class OnboardingReviewUpdatedContractsScreen extends StatelessWidget {
       onWillChange: (previousViewModel, newViewModel) {
         if (newViewModel.isAuthorized == true) {
           Navigator.pushNamedAndRemoveUntil(context, OnboardingSignWithTanScreen.routeName, (_) => false);
+        } else if (newViewModel.errorType != null) {
+          Navigator.pushNamedAndRemoveUntil(
+            context,
+            OnboardingIdentityVerificationErrorScreen.routeName,
+            (route) => false,
+          );
         }
       },
+      distinct: true,
       builder: (context, viewModel) {
-        final isAuthorizationStatusValid = viewModel.identificationStatus == null ||
-            viewModel.identificationStatus == OnboardingIdentificationStatus.authorizationRequired;
-
         return ScreenScaffold(
-          body: isAuthorizationStatusValid && viewModel.errorType == null
-              ? Column(
-                  children: [
-                    AppToolbar(
-                      richTextTitle: StepRichTextTitle(step: 4, totalSteps: 7),
-                      actions: const [AppbarLogo()],
-                      padding: ClientConfig.getCustomClientUiSettings().defaultScreenHorizontalPadding,
-                    ),
-                    AnimatedLinearProgressIndicator.step(current: 4, totalSteps: 7),
-                    const SizedBox(height: 16),
-                    viewModel.isLoading == true && viewModel.identificationStatus == null
-                        ? _buildLoadingContent()
-                        : _buildPageContent(context, viewModel),
-                    const SizedBox(height: 16),
-                  ],
-                )
-              : _buildErrorPage(),
+          body: Column(
+            children: [
+              AppToolbar(
+                richTextTitle: StepRichTextTitle(step: 4, totalSteps: 7),
+                actions: const [AppbarLogo()],
+                padding: ClientConfig.getCustomClientUiSettings().defaultScreenHorizontalPadding,
+              ),
+              AnimatedLinearProgressIndicator.step(current: 4, totalSteps: 7),
+              const SizedBox(height: 16),
+              viewModel.isLoading == true && viewModel.identificationStatus == null
+                  ? _buildLoadingContent()
+                  : _buildPageContent(context, viewModel),
+              const SizedBox(height: 16),
+            ],
+          ),
         );
       },
     );
@@ -90,65 +86,10 @@ class OnboardingReviewUpdatedContractsScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildErrorPage() {
-    return ScrollableScreenContainer(
-      padding: ClientConfig.getCustomClientUiSettings().defaultScreenPadding,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const AppToolbar(),
-          const ScreenTitle("Your identity verification has failed"),
-          const SizedBox(height: 16),
-          Text.rich(
-            TextSpan(
-              style: ClientConfig.getTextStyleScheme().bodyLargeRegular,
-              children: [
-                const TextSpan(text: 'We regret to inform you that your '),
-                TextSpan(
-                  text: 'identity verification ',
-                  style: ClientConfig.getTextStyleScheme().bodyLargeRegularBold,
-                ),
-                const TextSpan(text: 'has not been successful due to a '),
-                TextSpan(
-                  text: 'technical issue',
-                  style: ClientConfig.getTextStyleScheme().bodyLargeRegularBold,
-                ),
-                const TextSpan(text: '.\n\n'),
-                const TextSpan(text: 'Please get in touch with us by tapping on the '),
-                TextSpan(
-                  text: 'button below',
-                  style: ClientConfig.getTextStyleScheme().bodyLargeRegularBold,
-                ),
-                const TextSpan(text: '.'),
-              ],
-            ),
-          ),
-          Expanded(
-            child: IvoryAssetWithBadge(
-              childWidget: SvgPicture(
-                SvgAssetLoader(
-                  'assets/images/repayment_more_credit.svg',
-                  colorMapper: IvoryColorMapper(
-                    baseColor: ClientConfig.getColorScheme().secondary,
-                  ),
-                ),
-              ),
-              childPosition: BadgePosition.topEnd(top: -5, end: 78),
-              isSuccess: false,
-            ),
-          ),
-          PrimaryButton(
-            text: "Contact us",
-            onPressed: () {},
-          ),
-          const SizedBox(height: 16),
-        ],
-      ),
-    );
-  }
-
   Widget _buildPageContent(
-      BuildContext context, OnboardingIdentityVerificationViewModel identityVerificationViewModel) {
+    BuildContext context,
+    OnboardingIdentityVerificationViewModel identityVerificationViewModel,
+  ) {
     return Expanded(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/screens/onboarding/identity_verification/onboarding_scoring_waiting_screen.dart
+++ b/lib/screens/onboarding/identity_verification/onboarding_scoring_waiting_screen.dart
@@ -32,6 +32,7 @@ class OnboardingScoringWaitingScreen extends StatelessWidget {
           Navigator.pushNamedAndRemoveUntil(context, OnboardingScoringRejectedScreen.routeName, (route) => false);
         }
       },
+      distinct: true,
       builder: (context, viewModel) => ScreenScaffold(
         body: Column(
           children: [

--- a/lib/screens/onboarding/onboarding_stepper_screen.dart
+++ b/lib/screens/onboarding/onboarding_stepper_screen.dart
@@ -158,32 +158,32 @@ class OnboardingStepper extends StatelessWidget {
       type: StepperItemType.signUp,
       title: 'Sign up',
       description: 'Fill in your title, name, email address and choose your password. It\'s that easy.',
-      timeEstimation: 2,
+      timeEstimation: "2 MIN",
     ),
     OnboardingStepperItem(
       type: StepperItemType.personalDetails,
       title: 'Personal details',
       description: 'We\'ll need a few personal details from you. Rest assured your data is in good hands with us.',
-      timeEstimation: 3,
+      timeEstimation: "3 MIN",
     ),
     OnboardingStepperItem(
       type: StepperItemType.financialDetails,
       title: 'Financial details',
       description:
           'Tailored to your financial needs, we\'ll gather essential information through a few simple questions.',
-      timeEstimation: 5,
+      timeEstimation: "5 MIN",
     ),
     OnboardingStepperItem(
       type: StepperItemType.identityVerification,
       title: 'Identity verification',
       description: 'Verify your identity quickly and easily with your preferred method.',
-      timeEstimation: 3,
+      timeEstimation: "5-15 MIN",
     ),
     OnboardingStepperItem(
       type: StepperItemType.cardConfiguration,
       title: 'Card configuration',
       description: 'Provide your reference account, select your repayment option and let\'s get you your credit card.',
-      timeEstimation: 1,
+      timeEstimation: "1 MIN",
     ),
   ];
 }
@@ -235,7 +235,7 @@ class OnboardingStepListTile extends StatelessWidget {
                 if (state == OnboardingStepState.inProgress) ...[
                   Row(
                     children: [
-                      Text('${item.timeEstimation} MIN', style: ClientConfig.getTextStyleScheme().labelCaps),
+                      Text(item.timeEstimation, style: ClientConfig.getTextStyleScheme().labelCaps),
                       const SizedBox(width: 8),
                       SvgPicture.asset('assets/icons/clock.svg', width: 16, height: 16),
                     ],
@@ -243,7 +243,7 @@ class OnboardingStepListTile extends StatelessWidget {
                 ] else if (state == OnboardingStepState.notStarted) ...[
                   Row(
                     children: [
-                      Text('${item.timeEstimation} MIN',
+                      Text(item.timeEstimation,
                           style: ClientConfig.getTextStyleScheme()
                               .labelCaps
                               .copyWith(color: ClientConfig.getCustomColors().neutral500)),
@@ -345,7 +345,7 @@ class OnboardingStepperItem {
   final StepperItemType type;
   final String title;
   final String description;
-  final int timeEstimation;
+  final String timeEstimation;
 
   const OnboardingStepperItem({
     required this.type,

--- a/lib/widgets/modal.dart
+++ b/lib/widgets/modal.dart
@@ -20,6 +20,7 @@ Future<dynamic> showBottomModal({
     backgroundColor: Colors.white,
     useSafeArea: useSafeArea,
     isDismissible: isDismissible,
+    enableDrag: isDismissible,
     shape: const RoundedRectangleBorder(
       borderRadius: BorderRadius.only(
         topLeft: Radius.circular(24),

--- a/test/infrastructure/onboarding/onboarding_identity_verification_presenter_test.dart
+++ b/test/infrastructure/onboarding/onboarding_identity_verification_presenter_test.dart
@@ -243,5 +243,27 @@ void main() {
         ),
       );
     });
+
+    test("when state isIdentificationSuccessful is not null, should return to viewModel", () {
+      // given
+      const onboardingIdentityVerificationState = OnboardingIdentityVerificationState(
+        isLoading: false,
+        isIdentificationSuccessful: true,
+      );
+
+      // when
+      final viewModel = OnboardingIdentityVerificationPresenter.present(
+        identityVerificationState: onboardingIdentityVerificationState,
+      );
+
+      // then
+      expect(
+        viewModel,
+        const OnboardingIdentityVerificationViewModel(
+          isLoading: false,
+          isIdentificationSuccessful: true,
+        ),
+      );
+    });
   });
 }

--- a/test/redux/onboarding/identity_verification/onboarding_identity_verification_mocks.dart
+++ b/test/redux/onboarding/identity_verification/onboarding_identity_verification_mocks.dart
@@ -42,6 +42,25 @@ class FakeOnbordingIdentityVerificationService extends OnbordingIdentityVerifica
   Future<IdentityVerificationServiceResponse> authorizeIdentification({required User user}) async {
     return AuthorizeIdentificationSuccessResponse();
   }
+
+  @override
+  Future<IdentityVerificationServiceResponse> signWithTan({required User user, required String tan}) async {
+    return SignWithTanSuccessResponse();
+  }
+
+  @override
+  Future<IdentityVerificationServiceResponse> getCreditLimit({
+    required User user,
+  }) async {
+    return const GetCreditLimitSuccessResponse(creditLimit: 1000);
+  }
+
+  @override
+  Future<IdentityVerificationServiceResponse> finalizeIdentification({
+    required User user,
+  }) async {
+    return FinalizeIdentificationSuccessResponse();
+  }
 }
 
 class FakeFailingOnbordingIdentityVerificationService extends OnbordingIdentityVerificationService {
@@ -66,23 +85,12 @@ class FakeFailingOnbordingIdentityVerificationService extends OnbordingIdentityV
   Future<IdentityVerificationServiceResponse> authorizeIdentification({required User user}) async {
     return const IdentityVerificationServiceErrorResponse(errorType: OnboardingIdentityVerificationErrorType.unknown);
   }
-}
 
-class FakeOnbordingSignWithTanService extends OnbordingIdentityVerificationService {
-  @override
-  Future<IdentityVerificationServiceResponse> signWithTan({required User user, required String tan}) async {
-    return SignWithTanSuccessResponse();
-  }
-}
-
-class FakeFailingOnbordingSignWithTanService extends OnbordingIdentityVerificationService {
   @override
   Future<IdentityVerificationServiceResponse> signWithTan({required User user, required String tan}) async {
     return const IdentityVerificationServiceErrorResponse(errorType: OnboardingIdentityVerificationErrorType.unknown);
   }
-}
 
-class FakeOnbordingCreditLimitService extends OnbordingIdentityVerificationService {
   @override
   Future<IdentityVerificationServiceResponse> getCreditLimit({
     required User user,
@@ -94,6 +102,6 @@ class FakeOnbordingCreditLimitService extends OnbordingIdentityVerificationServi
   Future<IdentityVerificationServiceResponse> finalizeIdentification({
     required User user,
   }) async {
-    return FinalizeIdentificationSuccessResponse();
+    return const IdentityVerificationServiceErrorResponse(errorType: OnboardingIdentityVerificationErrorType.unknown);
   }
 }

--- a/test/redux/onboarding/identity_verification/onboarding_identity_verification_test.dart
+++ b/test/redux/onboarding/identity_verification/onboarding_identity_verification_test.dart
@@ -349,7 +349,7 @@ void main() {
     });
   });
 
-  group('credit limit', () {
+  group('fetching credit limit', () {
     const mockCreditLimit = 1000;
 
     test('when credit limit was ordered it should display loading state', () async {
@@ -400,7 +400,10 @@ void main() {
       expect(creditLimitState.isLoading, false);
       expect(creditLimitState.creditLimit, mockCreditLimit ~/ 100);
     });
+  });
 
+  group("finalize identification", () {
+    const mockCreditLimit = 1000;
     test('when requesting the finalizing step, it should display the credit limit and loading state', () async {
       //given
       final store = createTestStore(
@@ -424,6 +427,37 @@ void main() {
       final creditLimitState = (await appState).onboardingIdentityVerificationState;
 
       expect(creditLimitState.isLoading, true);
+      expect(creditLimitState.creditLimit, mockCreditLimit);
+    });
+
+    test(
+        "when finalize is successful, the isIdentificationSuccessful should be true and creditLimit should not be null",
+        () async {
+      // given
+      final store = createTestStore(
+        onboardingIdentityVerificationService: FakeOnbordingCreditLimitService(),
+        initialState: createAppState(
+          authState: authInitializedState,
+          onboardingIdentityVerificationState: const OnboardingIdentityVerificationState(
+            isLoading: false,
+            creditLimit: mockCreditLimit,
+            isIdentificationSuccessful: null,
+          ),
+        ),
+      );
+
+      final appState = store.onChange.firstWhere((state) =>
+          state.onboardingIdentityVerificationState.isLoading == false &&
+          state.onboardingIdentityVerificationState.isIdentificationSuccessful == true);
+
+      // when
+      store.dispatch(FinalizeIdentificationCommandAction());
+
+      // then
+      final creditLimitState = (await appState).onboardingIdentityVerificationState;
+
+      expect(creditLimitState.isLoading, false);
+      expect(creditLimitState.isIdentificationSuccessful, true);
       expect(creditLimitState.creditLimit, mockCreditLimit);
     });
   });

--- a/test/redux/onboarding/identity_verification/onboarding_identity_verification_test.dart
+++ b/test/redux/onboarding/identity_verification/onboarding_identity_verification_test.dart
@@ -274,7 +274,7 @@ void main() {
     test('when tan was sent it should display loading state', () async {
       //given
       final store = createTestStore(
-        onboardingIdentityVerificationService: FakeOnbordingSignWithTanService(),
+        onboardingIdentityVerificationService: FakeOnbordingIdentityVerificationService(),
         initialState: createAppState(
           authState: authInitializedState,
           onboardingIdentityVerificationState: const OnboardingIdentityVerificationState(
@@ -299,7 +299,7 @@ void main() {
     test('when tan successful sent it should update with success', () async {
       //given
       final store = createTestStore(
-        onboardingIdentityVerificationService: FakeOnbordingSignWithTanService(),
+        onboardingIdentityVerificationService: FakeOnbordingIdentityVerificationService(),
         initialState: createAppState(
           authState: authInitializedState,
           onboardingIdentityVerificationState: const OnboardingIdentityVerificationState(
@@ -325,7 +325,7 @@ void main() {
     test('when tan unsuccessful sent it should update with error', () async {
       //given
       final store = createTestStore(
-        onboardingIdentityVerificationService: FakeFailingOnbordingSignWithTanService(),
+        onboardingIdentityVerificationService: FakeFailingOnbordingIdentityVerificationService(),
         initialState: createAppState(
           authState: authInitializedState,
           onboardingIdentityVerificationState: const OnboardingIdentityVerificationState(
@@ -355,7 +355,7 @@ void main() {
     test('when credit limit was ordered it should display loading state', () async {
       //given
       final store = createTestStore(
-        onboardingIdentityVerificationService: FakeOnbordingCreditLimitService(),
+        onboardingIdentityVerificationService: FakeOnbordingIdentityVerificationService(),
         initialState: createAppState(
           authState: authInitializedState,
           onboardingIdentityVerificationState: const OnboardingIdentityVerificationState(
@@ -379,7 +379,7 @@ void main() {
     test('when credit limit is successful fetched it should be displayed', () async {
       //given
       final store = createTestStore(
-        onboardingIdentityVerificationService: FakeOnbordingCreditLimitService(),
+        onboardingIdentityVerificationService: FakeOnbordingIdentityVerificationService(),
         initialState: createAppState(
           authState: authInitializedState,
           onboardingIdentityVerificationState: const OnboardingIdentityVerificationState(
@@ -407,7 +407,7 @@ void main() {
     test('when requesting the finalizing step, it should display the credit limit and loading state', () async {
       //given
       final store = createTestStore(
-        onboardingIdentityVerificationService: FakeOnbordingCreditLimitService(),
+        onboardingIdentityVerificationService: FakeOnbordingIdentityVerificationService(),
         initialState: createAppState(
           authState: authInitializedState,
           onboardingIdentityVerificationState: const OnboardingIdentityVerificationState(
@@ -435,7 +435,7 @@ void main() {
         () async {
       // given
       final store = createTestStore(
-        onboardingIdentityVerificationService: FakeOnbordingCreditLimitService(),
+        onboardingIdentityVerificationService: FakeOnbordingIdentityVerificationService(),
         initialState: createAppState(
           authState: authInitializedState,
           onboardingIdentityVerificationState: const OnboardingIdentityVerificationState(
@@ -459,6 +459,40 @@ void main() {
       expect(creditLimitState.isLoading, false);
       expect(creditLimitState.isIdentificationSuccessful, true);
       expect(creditLimitState.creditLimit, mockCreditLimit);
+    });
+
+    test(
+        "when finalize has failed, the errorType and creditLimit should not be null and isIdentificationSuccessful should be false",
+        () async {
+      // given
+      final store = createTestStore(
+        onboardingIdentityVerificationService: FakeFailingOnbordingIdentityVerificationService(),
+        initialState: createAppState(
+          authState: authInitializedState,
+          onboardingIdentityVerificationState: const OnboardingIdentityVerificationState(
+            isLoading: false,
+            creditLimit: mockCreditLimit,
+            isIdentificationSuccessful: null,
+          ),
+        ),
+      );
+
+      final appState = store.onChange.firstWhere((state) =>
+          state.onboardingIdentityVerificationState.isLoading == false &&
+          state.onboardingIdentityVerificationState.errorType != null &&
+          state.onboardingIdentityVerificationState.creditLimit != null &&
+          state.onboardingIdentityVerificationState.isIdentificationSuccessful == false);
+
+      // when
+      store.dispatch(FinalizeIdentificationCommandAction());
+
+      // then
+      final creditLimitState = (await appState).onboardingIdentityVerificationState;
+
+      expect(creditLimitState.isLoading, false);
+      expect(creditLimitState.errorType, OnboardingIdentityVerificationErrorType.unknown);
+      expect(creditLimitState.creditLimit, mockCreditLimit);
+      expect(creditLimitState.isIdentificationSuccessful, false);
     });
   });
 }


### PR DESCRIPTION
## Changes

- Changed  `OnboardingStepperItem.timeEstimation` from `int` to `string`
- Changed time estimation of **Onboarding stepper/Identity verification** to `5-15 MIN` (according to Figma) 
- Changed time estimation of **Bank Identification** from `2 MIN` to `5 MIN` (Onboarding stepper/Identity verification/Step 1) 
- Added `distinct: true` to StoreConnector from ScoringWaitingScreen
- Added `FinalizeIdentificationErrorEventAction` which we need in order to persist the `creditLimit` value when the finalize identification fails (click on Continue from Credit Limit Congratulations Screen)
- Added `enableDrag: isDismissible` to `showModalBottomSheet( ... )`: this is useful to disable the drag-to-close the bottom sheet. Currently, we use `isDismissible: false` only when we display those "Server error" modals with "Try again" button

## Screenshots
https://github.com/ivoryio/Ivory/assets/127083262/c04803a9-3247-4dae-97e5-686bb85a0334

> #### Identity verification time estimation 5-15 MIN
> 
> ![Screenshot 2023-12-12 at 14 42 08](https://github.com/ivoryio/Ivory/assets/127083262/82229143-75a5-4e58-831d-cebded460d92)
>
> #### Bank Identification time estimation 5 MIN
> ![Screenshot 2023-12-12 at 14 53 16](https://github.com/ivoryio/Ivory/assets/127083262/cc802aaf-1ef8-4028-9a76-25b02f3dadc8)
>
> #### Server error modal
> https://github.com/ivoryio/Ivory/assets/127083262/c48ebb29-fdb2-45e6-8b8a-90fd70de9e2b




