### PR TITLE
[SOL-476] Home screen loading skeleton

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -82,6 +82,7 @@ class HomePageContent extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const HomePageHeader(),
+          const SizedBox(height: 32),
           Column(
             children: [
               Padding(
@@ -97,8 +98,9 @@ class HomePageContent extends StatelessWidget {
                     forceReloadTransactions: false,
                   ),
                 ),
-                converter: (store) =>
-                    TransactionPresenter.presentTransactions(transactionsState: store.state.homePageTransactionsState),
+                converter: (store) => TransactionPresenter.presentTransactions(
+                  transactionsState: store.state.homePageTransactionsState,
+                ),
                 builder: (context, viewModel) {
                   if (viewModel is TransactionsErrorViewModel) {
                     return const Center(
@@ -107,33 +109,49 @@ class HomePageContent extends StatelessWidget {
                   }
 
                   if (viewModel is TransactionsFetchedViewModel) {
+                    final transactions = viewModel.transactions ?? [];
+
                     return Column(
                       children: [
-                        for (var transaction in viewModel.transactions!)
-                          TransactionListItem(
-                            transaction: transaction,
+                        if (transactions.isEmpty)
+                          Padding(
+                            padding: ClientConfig.getCustomClientUiSettings().defaultScreenHorizontalPadding,
+                            child: Text(
+                              "No transactions yet. When you make payments & transactions, they will be displayed here.",
+                              style: ClientConfig.getTextStyleScheme().bodyLargeRegular,
+                            ),
                           ),
+                        for (var transaction in transactions) TransactionListItem(transaction: transaction),
+                        const SizedBox(height: 32),
                         Padding(
-                          padding: const EdgeInsets.symmetric(
-                            vertical: 24,
-                            horizontal: 24,
-                          ),
+                          padding: ClientConfig.getCustomClientUiSettings().defaultScreenHorizontalPadding,
                           child: Analytics(
                             transactions: viewModel.transactions!,
                           ),
                         ),
+                        const SizedBox(height: 32),
+                        Padding(
+                          padding: ClientConfig.getCustomClientUiSettings().defaultScreenHorizontalPadding,
+                          child: const Rewards(),
+                        )
                       ],
                     );
                   }
 
-                  return const Center(child: CircularProgressIndicator());
+                  return SkeletonContainer(
+                    child: Padding(
+                      padding: ClientConfig.getCustomClientUiSettings().defaultScreenHorizontalPadding,
+                      child: Column(
+                        children: [
+                          for (var i = 0; i < _defaultCountTransactionsDisplayed; i++)
+                            TransactionListItem.loadingSkeleton()
+                        ],
+                      ),
+                    ),
+                  );
                 },
               ),
             ],
-          ),
-          Padding(
-            padding: ClientConfig.getCustomClientUiSettings().defaultScreenHorizontalPadding,
-            child: const Rewards(),
           ),
         ],
       ),
@@ -209,6 +227,7 @@ class AccountSummary extends StatelessWidget {
 
   static Widget loadingSkeleton() {
     return const SkeletonContainer(
+      colorTheme: SkeletonColorTheme.light,
       child: Column(
         children: [
           SizedBox(height: 12),

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -10,6 +10,7 @@ import 'package:solarisdemo/screens/transactions/transactions_screen.dart';
 import 'package:solarisdemo/screens/transfer/transfer_screen.dart';
 import 'package:solarisdemo/widgets/rewards.dart';
 import 'package:solarisdemo/widgets/screen.dart';
+import 'package:solarisdemo/widgets/skeleton.dart';
 
 import '../../config.dart';
 import '../../infrastructure/transactions/transaction_presenter.dart';
@@ -154,42 +155,31 @@ class HomePageHeader extends StatelessWidget {
       converter: (store) =>
           AccountSummaryPresenter.presentAccountSummary(accountSummaryState: store.state.accountSummaryState),
       builder: (context, viewModel) {
-        if (viewModel is AccountSummaryFetchedViewModel || viewModel is AccountSummaryLoadingViewModel) {
-          return Container(
-            padding: ClientConfig.getCustomClientUiSettings().defaultScreenHorizontalPadding,
-            width: MediaQuery.of(context).size.width,
-            decoration: BoxDecoration(
-              borderRadius: const BorderRadius.only(
-                bottomLeft: Radius.circular(30),
-                bottomRight: Radius.circular(30),
+        return Container(
+          padding: ClientConfig.getCustomClientUiSettings().defaultScreenHorizontalPadding,
+          width: MediaQuery.of(context).size.width,
+          decoration: BoxDecoration(
+            borderRadius: const BorderRadius.only(
+              bottomLeft: Radius.circular(30),
+              bottomRight: Radius.circular(30),
+            ),
+            color: ClientConfig.getColorScheme().primary,
+          ),
+          child: Column(
+            children: [
+              viewModel is AccountSummaryFetchedViewModel
+                  ? AccountSummary(
+                      viewModel: viewModel,
+                    )
+                  : Center(child: AccountSummary.loadingSkeleton()),
+              Divider(
+                color: ClientConfig.getCustomColors().neutral100.withOpacity(0.15),
+                thickness: 1,
               ),
-              color: ClientConfig.getColorScheme().primary,
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                if (viewModel is AccountSummaryFetchedViewModel)
-                  AccountSummary(
-                    viewModel: viewModel,
-                  )
-                else
-                  const Center(
-                    child: Padding(
-                      padding: EdgeInsets.all(20.0),
-                      child: CircularProgressIndicator(color: Colors.white),
-                    ),
-                  ),
-                const Divider(
-                  color: Colors.white,
-                  thickness: 0.5,
-                ),
-                const AccountOptions(),
-              ],
-            ),
-          );
-        }
-
-        return const Text("Could not load account summary");
+              const AccountOptions(),
+            ],
+          ),
+        );
       },
     );
   }
@@ -216,6 +206,38 @@ class AccountSummary extends StatelessWidget {
       ],
     );
   }
+
+  static Widget loadingSkeleton() {
+    return const SkeletonContainer(
+      child: Column(
+        children: [
+          SizedBox(height: 12),
+          Skeleton(height: 16, width: 136),
+          SizedBox(height: 12),
+          Skeleton(height: 40, width: 192),
+          SizedBox(height: 12),
+          Skeleton(height: 8),
+          SizedBox(height: 12),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Skeleton(height: 10, width: 64),
+              Skeleton(height: 10, width: 64),
+            ],
+          ),
+          SizedBox(height: 8),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Skeleton(height: 16, width: 88),
+              Skeleton(height: 16, width: 88),
+            ],
+          ),
+          SizedBox(height: 20),
+        ],
+      ),
+    );
+  }
 }
 
 class AccountBalance extends StatelessWidget {
@@ -240,15 +262,17 @@ class AccountBalance extends StatelessWidget {
               "Available Balance",
               style: ClientConfig.getTextStyleScheme().labelSmall.copyWith(color: Colors.white),
             ),
-            IconButton(
-              icon: const Icon(
+            const SizedBox(width: 4),
+            InkWell(
+              child: const Icon(
                 Icons.info_outline,
                 color: Colors.white,
+                size: 24,
               ),
-              onPressed: () {
+              onTap: () {
                 Navigator.of(context).pushNamed(AvailableBalanceScreen.routeName, arguments: viewModel);
               },
-            ),
+            )
           ],
         ),
         Padding(
@@ -260,6 +284,7 @@ class AccountBalance extends StatelessWidget {
           ),
         ),
         LinearPercentIndicator(
+          padding: EdgeInsets.zero,
           lineHeight: 8,
           barRadius: const Radius.circular(40),
           percent: creditLimitPercent.isNaN ? 0 : creditLimitPercent,
@@ -283,7 +308,7 @@ class AccountStats extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 15, horizontal: 16),
+      padding: const EdgeInsets.only(top: 8, bottom: 16),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [

--- a/lib/widgets/skeleton.dart
+++ b/lib/widgets/skeleton.dart
@@ -22,7 +22,7 @@ class SkeletonContainer extends StatelessWidget {
 
   const SkeletonContainer({
     super.key,
-    this.colorTheme = SkeletonColorTheme.light,
+    this.colorTheme = SkeletonColorTheme.dark,
     this.animationDuration,
     this.animationEnabled = true,
     required this.child,

--- a/lib/widgets/skeleton.dart
+++ b/lib/widgets/skeleton.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+import 'package:solarisdemo/config.dart';
+
+enum SkeletonColorTheme { light, dark }
+
+class SkeletonTheme {
+  final Color baseColor;
+  final Color highlightColor;
+
+  const SkeletonTheme({
+    required this.baseColor,
+    required this.highlightColor,
+  });
+}
+
+class SkeletonContainer extends StatelessWidget {
+  final SkeletonColorTheme colorTheme;
+  final Duration? animationDuration;
+  final Widget child;
+  final bool animationEnabled;
+
+  const SkeletonContainer({
+    super.key,
+    this.colorTheme = SkeletonColorTheme.light,
+    this.animationDuration,
+    this.animationEnabled = true,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Shimmer.fromColors(
+      baseColor: _theme.baseColor,
+      highlightColor: _theme.highlightColor,
+      period: animationDuration ?? const Duration(milliseconds: 1500),
+      enabled: animationEnabled,
+      child: child,
+    );
+  }
+
+  SkeletonTheme get _theme {
+    final map = {
+      SkeletonColorTheme.light: SkeletonTheme(
+        baseColor: ClientConfig.getCustomColors().neutral100.withOpacity(0.15),
+        highlightColor: ClientConfig.getCustomColors().neutral100.withOpacity(0.02),
+      ),
+      SkeletonColorTheme.dark: SkeletonTheme(
+        baseColor: ClientConfig.getCustomColors().neutral900.withOpacity(0.15),
+        highlightColor: ClientConfig.getCustomColors().neutral900.withOpacity(0.05),
+      ),
+    };
+
+    return map[colorTheme]!;
+  }
+}
+
+class Skeleton extends StatelessWidget {
+  final BorderRadiusGeometry borderRadius;
+  final double? width;
+  final double? height;
+  final EdgeInsetsGeometry? padding;
+  final Widget? child;
+  final bool transparent;
+
+  const Skeleton({
+    super.key,
+    this.width,
+    this.height,
+    this.padding,
+    this.child,
+    this.transparent = false,
+    this.borderRadius = const BorderRadius.all(Radius.circular(100)),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: height,
+      width: width,
+      padding: padding,
+      decoration: BoxDecoration(
+        borderRadius: borderRadius,
+        color: Colors.white,
+        backgroundBlendMode: transparent ? BlendMode.clear : null,
+      ),
+      clipBehavior: Clip.none,
+      child: child,
+    );
+  }
+}

--- a/lib/widgets/transaction_listing_item.dart
+++ b/lib/widgets/transaction_listing_item.dart
@@ -67,7 +67,7 @@ class TransactionListItem extends StatelessWidget {
     return maxNameLength;
   }
 
-  static Widget loadingSkeleton({int count = 1}) {
+  static Widget loadingSkeleton() {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 16),
       child: Row(

--- a/lib/widgets/transaction_listing_item.dart
+++ b/lib/widgets/transaction_listing_item.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:intl/intl.dart';
 import 'package:solarisdemo/screens/transactions/transaction_detail_screen.dart';
+import 'package:solarisdemo/widgets/skeleton.dart';
 
 import '../config.dart';
 import '../models/transactions/transaction_model.dart';
@@ -64,6 +65,34 @@ class TransactionListItem extends StatelessWidget {
     }
 
     return maxNameLength;
+  }
+
+  static Widget loadingSkeleton({int count = 1}) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 16),
+      child: Row(
+        children: [
+          Skeleton(height: 24, width: 24, borderRadius: BorderRadius.circular(100)),
+          const SizedBox(width: 16),
+          const Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Skeleton(height: 16, width: 128),
+                    Spacer(),
+                    Skeleton(height: 16, width: 64),
+                  ],
+                ),
+                SizedBox(height: 8),
+                Skeleton(height: 10, width: 64),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -77,6 +77,7 @@ dependencies:
   webview_flutter: ^4.4.2
   pin_input_text_field: ^4.5.1
   plugin_platform_interface: ^2.1.7
+  shimmer: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Changes

- Changed spacings from the Home Screen according to figma 
- Display Spending analytics and Rewards sections only after transactions are fetched

## How to use the `Skeleton`

- The `Skeleton`  always has to be a child of a `SkeletonContainer` 

> ### `SkeletonContainer`
>  - `colorTheme` property of `SkeletonContainer` is needed to change the colors of the `Skeleton`(s)
>      - on dark backgrounds, use `colorTheme: SkeletonColorTheme.light`
>      - on light backgrounds, use `colorTheme: SkeletonColorTheme.dark` (default - doesn't need to be provided)

  
> ### `Skeleton`
>   - `transparent` (default to `false`):  use value `true` when the Skeleton is used as child of another Skeleton 
>  - To create a `Skeleton` with "holes" that allow the color from behind the `SkeletonContainer` to be visible, you should structure your widgets in the following way: The `SkeletonContainer` should have a `Skeleton` widget as its child. Then, any `Skeleton` widgets that are direct children of this `Skeleton` widget should have the `transparent: true` property set.

> Inside the `SkeletonContainer`, the widgets that have colors are not visible, only the `Skeleton`
> A good idea is to create a `static` method on the widget to build the `Skeleton` 

> Example: 
>``` dart
>SkeletonContainer(
>  colorTheme: SkeletonColorTheme.light,
>  child: Column(
>    children: [
>      SizedBox(height: 12),
>      Skeleton(height: 16, width: 136),
>      SizedBox(height: 12),
>    ]
>  ),
>);
>```

## Screenshots:

https://github.com/ivoryio/Ivory/assets/127083262/602a1dcc-dd73-4c05-aabc-c981f855233b



