### PR TITLE
[SOL-500] Fix redirect to Congratulations after Scoring Success notification

### DIFF
--- a/lib/infrastructure/notifications/push_notification_service.dart
+++ b/lib/infrastructure/notifications/push_notification_service.dart
@@ -46,6 +46,8 @@ abstract class PushNotificationService extends ApiService {
   Future<String?> getToken();
 
   void handleTokenRefresh({required User user});
+
+  bool get isInitialized;
 }
 
 class FirebasePushNotificationService extends PushNotificationService {
@@ -56,11 +58,14 @@ class FirebasePushNotificationService extends PushNotificationService {
   FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
   GlobalKey<NavigatorState> navigatorKey = navigator.navigatorKey;
 
-  bool isInitialized = false;
+  bool _isInitialized = false;
 
   FirebasePushNotificationService({super.user, required this.storageService}) {
     handleAndroidLocalNotifications();
   }
+
+  @override
+  bool get isInitialized => _isInitialized;
 
   @override
   Future<void> init(Store<AppState> store) async {
@@ -111,7 +116,7 @@ class FirebasePushNotificationService extends PushNotificationService {
     FirebaseMessaging.instance.getInitialMessage().then(_onMessage); // App was terminated and notification clicked
     FirebaseMessaging.onMessage.listen(_pushNotificationReceived);
 
-    isInitialized = true;
+    _isInitialized = true;
   }
 
   @override
@@ -190,6 +195,7 @@ class FirebasePushNotificationService extends PushNotificationService {
     if (store == null) return;
 
     debugPrint("Redirect from notification");
+    navigatorKey;
     final context = navigatorKey.currentContext as BuildContext;
     final notificationType = RemoteMessageUtils.getNotificationType(message.data["type"] as String);
 
@@ -212,6 +218,10 @@ class FirebasePushNotificationService extends PushNotificationService {
 
   @override
   Future<void> handleSavedNotification() async {
+    if (!isInitialized || store == null) {
+      return;
+    }
+
     final message = await storageService.find();
     if (message == null) return;
 

--- a/lib/infrastructure/notifications/push_notification_service.dart
+++ b/lib/infrastructure/notifications/push_notification_service.dart
@@ -195,7 +195,6 @@ class FirebasePushNotificationService extends PushNotificationService {
     if (store == null) return;
 
     debugPrint("Redirect from notification");
-    navigatorKey;
     final context = navigatorKey.currentContext as BuildContext;
     final notificationType = RemoteMessageUtils.getNotificationType(message.data["type"] as String);
 

--- a/lib/infrastructure/notifications/push_notification_service_provider.dart
+++ b/lib/infrastructure/notifications/push_notification_service_provider.dart
@@ -1,0 +1,16 @@
+import 'package:solarisdemo/infrastructure/notifications/push_notification_service.dart';
+
+class PushNotificationServiceProvider {
+  PushNotificationServiceProvider._();
+
+  static final PushNotificationServiceProvider instance = PushNotificationServiceProvider._();
+
+  late PushNotificationService _service;
+
+  factory PushNotificationServiceProvider.init(PushNotificationService service) {
+    instance._service = service;
+    return instance;
+  }
+
+  PushNotificationService get service => _service;
+}

--- a/lib/infrastructure/notifications/push_notification_storage_service.dart
+++ b/lib/infrastructure/notifications/push_notification_storage_service.dart
@@ -26,7 +26,7 @@ class PushNotificationSharedPreferencesStorageService extends PushNotificationSt
   @override
   Future<String?> find() async {
     final sharedPreferences = await _sharedPreferences;
-    sharedPreferences.reload();
+    await sharedPreferences.reload();
 
     return (sharedPreferences).getString(_key);
   }

--- a/lib/ivory_app.dart
+++ b/lib/ivory_app.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:redux/redux.dart';
 import 'package:solarisdemo/config.dart';
+import 'package:solarisdemo/infrastructure/notifications/push_notification_service_provider.dart';
 import 'package:solarisdemo/navigator_observers/general_navigation_observer.dart';
 import 'package:solarisdemo/navigator_observers/navigation_logging_observer.dart';
 import 'package:solarisdemo/models/home/main_navigation_screens.dart';
@@ -132,6 +133,8 @@ class _IvoryAppState extends State<IvoryApp> with WidgetsBindingObserver {
       final store = widget.store;
 
       forceReloadAppStates(store);
+    } else if (state == AppLifecycleState.resumed) {
+      PushNotificationServiceProvider.instance.service.handleSavedNotification();
     }
   }
 

--- a/lib/ivory_app.dart
+++ b/lib/ivory_app.dart
@@ -132,9 +132,9 @@ class _IvoryAppState extends State<IvoryApp> with WidgetsBindingObserver {
     if (state == AppLifecycleState.hidden) {
       final store = widget.store;
 
-      forceReloadAppStates(store);
-    } else if (state == AppLifecycleState.resumed) {
-      PushNotificationServiceProvider.instance.service.handleSavedNotification();
+      PushNotificationServiceProvider.instance.service
+          .handleSavedNotification()
+          .then((_) => forceReloadAppStates(store));
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:solarisdemo/infrastructure/documents/documents_service.dart';
 import 'package:solarisdemo/infrastructure/documents/file_saver_service.dart';
 import 'package:solarisdemo/infrastructure/mobile_number/mobile_number_service.dart';
 import 'package:solarisdemo/infrastructure/notifications/push_notification_service.dart';
+import 'package:solarisdemo/infrastructure/notifications/push_notification_service_provider.dart';
 import 'package:solarisdemo/infrastructure/notifications/push_notification_storage_service.dart';
 import 'package:solarisdemo/infrastructure/onboarding/card_configuration/onboarding_card_configuration_service.dart';
 import 'package:solarisdemo/infrastructure/onboarding/financial_details/onboarding_financial_details_service.dart';
@@ -53,7 +54,13 @@ Future<void> main() async {
 
   await SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp, DeviceOrientation.portraitDown]);
 
-  final store = _buildStore();
+  PushNotificationServiceProvider.init(FirebasePushNotificationService(
+    storageService: PushNotificationSharedPreferencesStorageService(),
+  ));
+
+  final pushNotificationService = PushNotificationServiceProvider.instance.service;
+
+  final store = _buildStore(pushNotificationService);
 
   runApp(IvoryApp(
     clientConfig: clientConfig,
@@ -61,12 +68,10 @@ Future<void> main() async {
   ));
 }
 
-Store<AppState> _buildStore() {
+Store<AppState> _buildStore(PushNotificationService pushNotificationService) {
   final store = createStore(
     initialState: AppState.initialState(),
-    pushNotificationService: FirebasePushNotificationService(
-      storageService: PushNotificationSharedPreferencesStorageService(),
-    ),
+    pushNotificationService: pushNotificationService,
     transactionService: TransactionService(),
     creditLineService: CreditLineService(),
     repaymentReminderService: RepaymentReminderService(),

--- a/test/infrastructure/notifications/firebase_messaging_mocks.dart
+++ b/test/infrastructure/notifications/firebase_messaging_mocks.dart
@@ -64,8 +64,11 @@ class MockFirebaseMessaging extends Mock with MockPlatformInterfaceMixin impleme
 
   @override
   Future<RemoteMessage?> getInitialMessage() {
-    return super.noSuchMethod(Invocation.method(#getInitialMessage, []),
-        returnValue: neverEndingFuture<RemoteMessage>(), returnValueForMissingStub: neverEndingFuture<RemoteMessage>());
+    return super.noSuchMethod(
+      Invocation.method(#getInitialMessage, []),
+      returnValue: Future.value(null),
+      returnValueForMissingStub: Future.value(null),
+    );
   }
 
   @override
@@ -112,17 +115,17 @@ class MockFirebaseMessaging extends Mock with MockPlatformInterfaceMixin impleme
     bool? sound = true,
   }) {
     return super.noSuchMethod(
-        Invocation.method(#requestPermission, [], {
-          #alert: alert,
-          #announcement: announcement,
-          #badge: badge,
-          #carPlay: carPlay,
-          #criticalAlert: criticalAlert,
-          #provisional: provisional,
-          #sound: sound
-        }),
-        returnValue: neverEndingFuture<NotificationSettings>(),
-        returnValueForMissingStub: neverEndingFuture<NotificationSettings>());
+      Invocation.method(#requestPermission, [], {
+        #alert: alert,
+        #announcement: announcement,
+        #badge: badge,
+        #carPlay: carPlay,
+        #criticalAlert: criticalAlert,
+        #provisional: provisional,
+        #sound: sound
+      }),
+      returnValue: Future.value(deniedNotificationSettings),
+    );
   }
 
   @override

--- a/test/infrastructure/notifications/push_notifications_service_mocks.dart
+++ b/test/infrastructure/notifications/push_notifications_service_mocks.dart
@@ -44,8 +44,8 @@ class MockPushNotificationStorageService extends Mock implements PushNotificatio
   Future<String?> find() {
     return super.noSuchMethod(
       Invocation.method(#find, []),
-      returnValue: Future<String>.value(''),
-      returnValueForMissingStub: Future<String>.value(''),
+      returnValue: Future<String>.value('{}'),
+      returnValueForMissingStub: Future<String>.value('{}'),
     );
   }
 }

--- a/test/redux/notification/notification_mocks.dart
+++ b/test/redux/notification/notification_mocks.dart
@@ -33,6 +33,9 @@ class FakeNotificationService extends PushNotificationService {
   Future<bool> hasPermission() {
     return Future.value(true);
   }
+
+  @override
+  bool get isInitialized => true;
 }
 
 class FakeNotificationServiceWithNoPermission extends PushNotificationService {
@@ -65,4 +68,7 @@ class FakeNotificationServiceWithNoPermission extends PushNotificationService {
   Future<bool> hasPermission() {
     return Future.value(false);
   }
+
+  @override
+  bool get isInitialized => false;
 }

--- a/test/setup/create_store.dart
+++ b/test/setup/create_store.dart
@@ -156,6 +156,9 @@ class NotImplementedPushNotificationService extends PushNotificationService {
   void handleTokenRefresh({User? user}) {
     throw UnimplementedError();
   }
+
+  @override
+  bool get isInitialized => throw UnimplementedError();
 }
 
 class NotImplementedTransactionService extends TransactionService {


### PR DESCRIPTION
## Changes 
- Added `PushNotificationServiceProvider` which is a singleton class that is used to get the `PushNotificationService` instance when the `AppStore` is built and when the app is coming from the background (this second case was mostly the reason why I needed it)
- Added `get bool isInitialized` to the `PushNotificationService` which should be `true` only after the service is initialized (and the user has given consent for notifications)
- Added a missing `await` to shared preferences `reload()` which caused shared preferences `getString()` to return null (when the data was saved actually)

## Screenshot

https://github.com/ivoryio/Ivory/assets/127083262/d56b3cce-28fd-41ff-b0b5-99ff08eeac18

